### PR TITLE
Literal-union @fit given domains

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -15,8 +15,10 @@ return.width: 0..320 // check fact. Freerange must prove this from source.
 a..b // JavaScript number in the inclusive interval from a to b.
 a..<b // JavaScript number from a up to, but not including, b.
 int a..b // integer in the inclusive interval from a to b.
+a | b | c // literal-union domain. The value is exactly one of the listed numbers. Two or more literals required; a single number is still `2..2`.
 width: number, // @fit 0..1000 // param shorthand for `given width: 0..1000`.
 width: number, // @fit >= min // param shorthand for `given width >= min`.
+searchSlot: number, // @fit 0 | 40 | 200 | 213 // param shorthand for a literal-union `given`.
 // @fit 0..100 // local/field/return shorthand for proving the attached value is in a range.
 // @fit <= max // local/field/return shorthand for proving the attached value `<= max`.
 items[] // every item in one anonymous collection.
@@ -158,6 +160,26 @@ Function-level `given` lines are still the right place for object paths, array p
  * given min <= max
  */
 ```
+
+When a parameter only takes a small known set of values, use a literal-union `given` instead of a range. The checker narrows the input to exactly those numbers, so downstream arithmetic keeps per-value identity:
+
+```ts
+/** @fit
+ * given navSizeX: 82 | 214
+ * return: 82 | 214
+ */
+function navColumn(navSizeX: number) {
+  return navSizeX
+}
+
+function widenSearchSlot(
+  searchSlot: number, // @fit 0 | 40 | 200 | 213
+) {
+  return searchSlot + 14 // @fit 14 | 54 | 214 | 227
+}
+```
+
+A range like `82..214` would also accept `150`; the literal union rejects it, and a call site passing a literal outside the set fails with `missing: x in {82, 214}`. If the param's TypeScript type is already a literal union (`navSizeX: 82 | 214`), the shape oracle picks it up automatically; the `given` is confirmation or documentation.
 
 `given` lines and param inline facts describe inputs your function expects. They do not ask Freerange to audit the function body by themselves.
 

--- a/mj-gallery-limitations.md
+++ b/mj-gallery-limitations.md
@@ -237,15 +237,17 @@ Keeping this entry because a future regression would re-surface as "`given` rang
 
 ---
 
-## 20. Range `given` on a parameter is a trust barrier, not a type check
+## 20. Literal-union types as `given` domains — fixed 2026-04-24
 
-Writing `given navSizeX: 82..214` buys no call-site enforcement — freerange assumes it holds. A refactor that introduces a third nav variant (`navSizeX: 96`) passes the contract but silently places rects 14px off.
+**Was a limitation; now fixed.** Documenting here so the workaround pattern doesn't re-emerge.
 
-**mj-gallery example:** The prod `imagineFrame` takes `navSizeX: 82..214` (collapsed = 82, expanded = 214). The dispatcher in React picks from `layout.navSizeX`. If a future tablet nav returns 96, every contract still "passes" because the number is in range, but the layout mis-positions.
+Before the fix, writing `given navSizeX: 82..214` bought no call-site enforcement — freerange assumed it held. A refactor introducing a third nav variant (`navSizeX: 96`) passed the contract but silently placed rects 14px off. There was no way to narrow the given to a discrete set.
 
-TypeScript can express this exactly (`navSizeX: 82 | 214`). Freerange currently can't use literal-union types as givens.
+**Fix:** `given` (in `@fit` blocks and inline `// @fit` param comments) now accepts literal-union numeric types such as `0 | 40 | 200 | 213`. The domain is the exact set of values; downstream per-branch cases flow through Math.min / subtraction exactly like the source-proved ternary cases in #19. Call sites that pass a literal not in the set now fail with `missing: x in {0, 40, 200, 213}` instead of range-widening.
 
-**What we want:** Accept TypeScript literal-union types as `given` domains. `given navSizeX: 82 | 214` should both narrow the domain to those two values AND get checked at every call site by the TS compiler. The frame proofs become sharper (no fake 96-valued case) and the contract becomes enforceable without trusting callers.
+Parser: `src/parser.ts::parseUnionText`. Checker: `src/check.ts::proveUnionSpec`. `patterns.ts::literalUnionGivenPassesThrough` and `patterns.ts::literalUnionGivenOnParam` are the positive regression tests. `negative-patterns.ts::negativeUnionReturnOutsideSet` is the negative regression test.
+
+If the parameter's TypeScript type is already a literal union like `searchSlot: 0 | 40 | 200 | 213`, the checker picks it up via its shape oracle the same way it reads structural shape today; the explicit `given` is confirmation or documentation for the spec block.
 
 ---
 

--- a/mj-gallery-limitations.md
+++ b/mj-gallery-limitations.md
@@ -1,0 +1,264 @@
+# Freerange Limitations Hit While Expressing mj-gallery Layout
+
+Running log of rough edges encountered while annotating the /imagine page layout with `@fit`. Each entry describes the limitation, a concrete example from mj-gallery, and what shape freerange should grow to accept. We want to shape freerange to match our real layout code, not bend the layout to satisfy the checker.
+
+Format: **limitation** → **mj-gallery example** → **what we want**
+
+---
+
+## 1. No booleans as facts
+
+`isSidebarOpen: boolean` can't be used in `@fit` givens or result facts. We had to pass `int 0..1` and write `isOpen === 1 ? ... : 0` at every branch.
+
+**mj-gallery example:** `GlobalContext.sidebarOpenState` is `'images' | 'settings' | 'filter' | null`. Callers collapse this to a boolean then have to collapse it again to a number before calling any checked helper.
+
+**What we want:** `given isOpen: boolean`, `given isOpen === true`, and ternaries / `if` guards on booleans should narrow result facts the same way they narrow `isOpen === 1`.
+
+---
+
+## 2. Per-branch result facts are erased at call boundaries
+
+`rightSidebarFootprint(isOpen, sideBarWidth)` returns `0` when closed and `sideBarWidth + 32` when open. The `@fit` can only state the union range `result: 0..sideBarWidth + 32`. A caller that passes `1` gets `0..sideBarWidth + 32` back, not the exact `sideBarWidth + 32`.
+
+**mj-gallery example:** `imaginePageFrame` needed to know footprint exactly `== sideBarWidth + 32` to chain the next proof step. We had to inline the constant in the caller, losing the helper abstraction.
+
+**What we want:** Overloaded contracts, or refinement contracts, or `@fit` "when" clauses: "when isOpen === 1, result == sideBarWidth + 32; when isOpen === 0, result == 0". Alternatively, infer from source body when the helper is small enough.
+
+---
+
+## 3. No discriminated-union / state-dependent contract
+
+A single function that returns different shapes based on a state flag can't express different invariants per branch. We had to split `imaginePageFrame` into `imaginePageFrameOpen` + `imaginePageFrameClosed`.
+
+**mj-gallery example:** On /imagine, when the right sidebar is open we want `content.right <= sidebar.left`; when closed there is no sidebar panel and that invariant is vacuous. One function returning `{state: 'open', ...} | {state: 'closed', ...}` would be the natural shape.
+
+**What we want:** `@fit` blocks that discriminate on the returned `state` field. Something like `if result.state == 'open' then result.content.right <= result.sidebar.left`.
+
+---
+
+## 4. No named geometric atoms (`rectInside`, `nonOverlapX`)
+
+Everything is spelled out as `a.right <= b.left`. For 4 rects in 2 axes, we write ~8 numeric comparisons when one atom would do it.
+
+**mj-gallery example:** On /imagine the user's mental model is "nav | content | sidebar horizontally, input above content". Each relation required 2 comparisons (left/right or top/bottom).
+
+**What we want:** Named atoms like `nonOverlapX(a, b)`, `horizontalOrder(nav, content, sidebar)`, `rectInside(child, parent)`. Each unfolds to the numeric comparisons but reads far better in the spec.
+
+---
+
+## 5. No cross-function facts / cross-module spans
+
+Facts about relationships are only checkable inside a single function that produces all the relevant values. The mj-gallery code is deliberately split across `Layout.ts` (produces `sideBarX`), `SidebarShell.tsx` (consumes it), `InputDesktop.tsx` (consumes `sideBarX` plus local math), etc.
+
+**mj-gallery example:** `InputDesktop.tsx` computes its own right edge as `sideBarX + sideBarSizeX - containerInnerX - inputInsetY`. We can't assert `input.right <= sidebar.left` across module boundaries without gathering everything into one function.
+
+**What we want:** Either a cross-module "layout contract" that a site can publish and another site can consume, or a way to say "this rect is the same rect as that one from module Y" so facts compose.
+
+---
+
+## 6. Weak linear reasoner forces verbose contracts
+
+Helpers' contracts had to sprout parametric bounds (`result <= containerSizeX - naturalInnerX - footprint`, `result >= innerRightX`) just so that callers could chain proofs. Simple range bounds weren't enough.
+
+**mj-gallery example:** `innerWidthAfterSidebar` initially had `result <= naturalInnerSizeX`. The caller needed `result <= containerSizeX - naturalInnerX - footprint` too (which is trivially true of `Math.min`) to prove that `containerInnerX + result <= containerSizeX - footprint`.
+
+**What we want:** Either auto-emit both bounds for `Math.min` / `Math.max`, or a richer linear solver that can combine `result <= A` with `result <= B` when the caller needs a specific B.
+
+---
+
+## 7. Preconditions cascade awkwardly into callers
+
+`innerWidthAfterSidebar` has `given containerSizeX >= naturalInnerX + footprint`. Every caller now has to prove that precondition, which cascades through each intermediate helper. Writing the contract feels defensive rather than declarative.
+
+**mj-gallery example:** Adding `given containerSizeX >= naturalInnerX + footprint` broke the prototype's call to `innerWidthAfterSidebar` until we added a matching given at the page-frame level. Now every new caller has to thread this.
+
+**What we want:** Default preconditions inferred from return-type assertions ("if you want `result >= 0`, you need containerSizeX >= naturalInnerX + footprint"), and diagnostics that say "you asked for X, so you now owe Y at every call site".
+
+---
+
+## 8. Numeric-only comparisons, no string/enum discrimination
+
+Can't write `given loute.type == 'archive'` or have the checker narrow behavior based on string discriminants.
+
+**mj-gallery example:** `archiveSidebarOffset` returns `12` for archive routes, `0` otherwise. The per-route behavior is invisible to the checker — we just give `archiveOffset: int 0..12` and the checker can't distinguish between /imagine (always 0) and /archive (always 12).
+
+**What we want:** String discriminants in givens (`given loute.type == 'imagine'`) and in return narrowing. This matches how real code branches.
+
+---
+
+## 9. No way to share a geometric "shape" across many functions
+
+`Rect = {left, right, top, bottom}` is just an object type. Every spec that talks about "rectangles" re-spells the fields. There's no primitive meaning attached.
+
+**mj-gallery example:** `ImaginePageFrame` has 4 rects; each rect has 4 fields; no way to say "these 4 numbers are a rectangle, and rectangles compose into layouts".
+
+**What we want:** First-class `Rect` primitive (or at least a tagged type) that layout atoms (`rectInside`, `nonOverlapX`) recognize, so the spec becomes geometric rather than arithmetic.
+
+---
+
+## 10. Can't reason about `boolean` narrowing from string equality
+
+A common pattern in mj-gallery: `const isArchive = loute.type === 'archive'`. Freerange doesn't narrow facts from this either, so even the numeric form `const archiveOffset = isArchive ? 12 : 0` loses the route-specific guarantee when passed down.
+
+**What we want:** Source inference that follows equality checks on discriminated unions and narrows downstream values the same way TypeScript does.
+
+---
+
+## 11. Helpers with a "mostly safe, sometimes tighter" contract need two variants
+
+`rightSidebarLeftX` is `Math.min(naturalX, clampedX) - archiveOffset`. The natural branch is tighter (result = innerRightX + 16) when enough room; the clamped branch kicks in otherwise. Callers that want to prove `result >= innerRightX` (the natural case) need to know the precondition holds. Callers that just want universal upper bounds don't.
+
+We couldn't put both in one `@fit` — a precondition on one claim applies to all. End result: we moved the lower-bound proof out of the helper into the open-frame function, where we inline the natural branch. This duplicates math between the frame and the helper.
+
+**mj-gallery example:** `imaginePageFrameOpen` inlines `sideBarLocalX = innerRight + SIDEBAR_GAP` instead of calling `rightSidebarLeftX`, precisely because freerange couldn't prove the stronger invariant through the helper.
+
+**What we want:** per-claim preconditions in `@fit`, or ergonomic way to express "this claim holds when X, that claim is universal". Alternatively, good conditional narrowing at the call site so one helper produces both claims naturally.
+
+---
+
+## 12. No per-call-site "instantiate this contract with reserve=0" narrowing
+
+The frame needs `rightStripReserve=0` and `archiveOffset=0` to prove the stronger invariants. The live Layout.ts calls with possibly-nonzero reserve/offset (for /archive etc.). We had to write `rightSidebarHorizontalPlacement` that branches: if zero, call the frame (proven); else, call the atomic helpers (weaker guarantees). The same code path exists in two shapes.
+
+**mj-gallery example:** The /imagine page gets frame-level verification; /archive gets only atom-level. One dispatcher `rightSidebarHorizontalPlacement` picks. The code has two paths for what's semantically one operation.
+
+**What we want:** Contracts parameterized on call-site constants — when the call is `helper(0, 0)`, freerange should specialize the contract and prove the stricter invariants; when it's `helper(12, 78)`, only the weaker ones.
+
+---
+
+## 13. `@fit` can't refer to result shape that depends on parameter values
+
+We wanted a single `imaginePageFrame(isSidebarOpen, ...)` whose returned `sidebar` field is only asserted to be non-overlapping with `content` when `isSidebarOpen === true`. No way to write that in `@fit`. We split into two functions and wrote a runtime dispatcher — the dispatcher itself has no proof.
+
+**mj-gallery example:** `imaginePageFrame` (the dispatcher in `ImaginePageFrame.ts`) is unchecked glue between two checked leaves. Callers reading through the dispatcher get fewer guarantees than if they call a leaf directly.
+
+**What we want:** Discriminated-union-aware `@fit` blocks, something like:
+```
+result.state == 'open' -> result.content.right <= result.sidebar.left
+result.state == 'closed' -> result.content.bottom <= result.sidebar.top
+```
+So the single entry point is verified end-to-end.
+
+---
+
+## 14. Composite layouts want `rectInside` / `nonOverlap` atoms
+
+Every 2-rect relationship expands to 2 numeric comparisons (left/right or top/bottom). A full page-frame spec on /imagine is 9+ numeric lines that together mean "these 4 rects are in the expected `[nav | content | sidebar] + input-above-content` arrangement".
+
+**mj-gallery example:** `imaginePageFrameOpen`'s `@fit` has ~10 comparisons spelling out a mental model that is 2 sentences.
+
+**What we want:** Named atoms. A spec that reads `horizontalOrder(nav, content, sidebar)` and `verticalOrder(input, content)` and `rectInside(content, viewport)` instead of the current wall of inequalities.
+
+---
+
+## 15. Helper boundaries erase branch facts; inlining `Math.min` proves more
+
+The clearest demonstration: we had a helper `rightSidebarLeftX = Math.min(A, B) - offset`. The caller couldn't prove `innerRight - result <= reserve + offset - 16` through the helper boundary — the @fit contract only carried universal upper bounds on `result`, not the two per-branch lower bounds that `Math.min`'s source-branch facts would have given us.
+
+**mj-gallery example:** `imaginePageFrameOpen` used to call the helper; the universal invariant `content.right <= sidebar.left + reserve + offset` was `unknown`. Inlining `Math.min` directly in the frame made it `pass` immediately — same arithmetic, same result, just removed the helper boundary.
+
+**What we want:** Helpers should carry their per-branch facts through the contract, or freerange should trace into short helper bodies when the caller needs a fact the contract doesn't spell out. Otherwise every caller with nontrivial proof goals will inline, defeating reuse.
+
+---
+
+## 16. "Trivial" helpers that only do a + or min don't earn their keep
+
+We built a handful of small helpers (`rightSidebarShellTop = gapTop + inputHeight + 8`, `fallbackRightSidebarWidth = Math.min(x, 350)`, `imagesSidebarHeight = y - a - b - 8`) so each call site could call a checked function. They're all arithmetic. Inlining at the call site is just as clear and removes five exports.
+
+**mj-gallery example:** After first pass, these four-line helpers all got inlined; only the meaty `Math.min`-cap and the frame function remain checked.
+
+**What we want:** Guidance in freerange docs about when a helper is worth carving out: it should hold a non-obvious branch fact, parameterize a named layout atom, or be called from many sites. Pure arithmetic inline is fine and often clearer.
+
+---
+
+## 17. Multi-ternary fan-out within a single function
+
+Two independent ternaries on the same discriminator aren't recognized as correlated. Freerange treats each ternary's cases independently and then cross-multiplies them, checking combinations that can't actually happen.
+
+**mj-gallery example (prod /imagine frame):**
+
+```ts
+const navContainerGap = collapsedNav === 1 ? 22 : 32
+const navInnerWidth   = collapsedNav === 1 ? 38 : 160
+const navSizeX = WINDOW_GAP_LEFT + navInnerWidth + navContainerGap
+```
+
+Freerange produced four cases for `navSizeX` — one of which mixed `(navInnerWidth=38, navContainerGap=32)`, arithmetic that can never run. Downstream `result.nav.right <= result.inputRow.left` failed against that fake case even though the real code paths satisfy it.
+
+Worked around by collapsing to a single ternary that picks the whole `navSizeX` as a literal:
+
+```ts
+const navSizeX =
+  collapsedNav === 1
+    ? WINDOW_GAP_LEFT + COLLAPSED_NAV_INNER + COLLAPSED_NAV_GAP
+    : WINDOW_GAP_LEFT + EXPANDED_NAV_INNER + EXPANDED_NAV_GAP
+```
+
+**Distinct from #3/#13** — those are about expressing *per-branch contracts*. This is about the checker inventing cases that don't exist when the source has multiple uses of the same discriminator.
+
+**What we want:** Either correlate ternaries that branch on the same identifier (treat them as one joint case split) or narrow downstream expressions by re-reading the discriminator at each ternary and proving the mixed combinations are unreachable.
+
+---
+
+## 18. Non-exported module consts with arithmetic initializers don't resolve
+
+A module-scope `const` whose initializer is any arithmetic over other constants silently becomes a non-numeric value inside the function body. Every downstream comparison that touches it fails with "Binary arithmetic expected numbers" and the locals it influences don't appear in `infer` output at all.
+
+**mj-gallery example:**
+
+```ts
+export const WINDOW_GAP_LEFT = 22
+export const WINDOW_GAP_RIGHT_EXTRA = 16
+const WINDOW_GAP_RIGHT = WINDOW_GAP_LEFT + WINDOW_GAP_RIGHT_EXTRA  // 38
+
+function imagineFrame(windowSizeX: number, navSizeX: number, ...) {
+  const availableInner = windowSizeX - navSizeX - WINDOW_GAP_RIGHT
+  ...
+}
+```
+
+10+ rect contracts flipped from `unknown` to `pass` the moment `WINDOW_GAP_RIGHT` was changed from the arithmetic expression to the literal `38`. No warning or hint points at this as the cause; the error messages only show the downstream comparisons failing.
+
+**Workarounds today:** Inline literals at module scope, or mark the const `export` (unverified whether export alone is enough — this example used a non-exported const and switching to a literal fixed it; worth testing if the export bit is the real trigger).
+
+**What we want:** Constant-fold top-level arithmetic-initialized `const`s the same way literal consts are resolved, regardless of export status. Or emit a diagnostic when such a const is referenced inside an `@fit`-checked function body so the author knows to inline.
+
+---
+
+## 19. `joinValues` used to drop per-branch cases for two plain-literal branches — fixed 2026-04-20
+
+**Was a limitation; now fixed.** Documenting here so the workaround pattern doesn't re-emerge.
+
+Before the fix, `joinValues` in `src/domain.ts` short-circuited to a plain range whenever neither branch had pre-existing cases — even when the two branches' values disagreed on linear form. A ternary like `flag ? 108 : 68` joined to `{min: 68, max: 108, linear: null}` with no cases. Downstream `Math.min(width, inset)` lost the per-branch fact that `inset` was literally 108 or 68, so `width - Math.min(width, inset) >= 0` went `unknown`.
+
+**Fix:** `joinValues` now preserves cases when the two branches disagree on linear form. `patterns.ts::pathSensitiveMinOverflowTernaryInset` is the regression test.
+
+Keeping this entry because a future regression would re-surface as "`given` ranges don't flow through `Math.min` when the input is ternary-assigned", and a search of this doc should turn up the fix rather than a re-diagnosis.
+
+---
+
+## 20. Range `given` on a parameter is a trust barrier, not a type check
+
+Writing `given navSizeX: 82..214` buys no call-site enforcement — freerange assumes it holds. A refactor that introduces a third nav variant (`navSizeX: 96`) passes the contract but silently places rects 14px off.
+
+**mj-gallery example:** The prod `imagineFrame` takes `navSizeX: 82..214` (collapsed = 82, expanded = 214). The dispatcher in React picks from `layout.navSizeX`. If a future tablet nav returns 96, every contract still "passes" because the number is in range, but the layout mis-positions.
+
+TypeScript can express this exactly (`navSizeX: 82 | 214`). Freerange currently can't use literal-union types as givens.
+
+**What we want:** Accept TypeScript literal-union types as `given` domains. `given navSizeX: 82 | 214` should both narrow the domain to those two values AND get checked at every call site by the TS compiler. The frame proofs become sharper (no fake 96-valued case) and the contract becomes enforceable without trusting callers.
+
+---
+
+## 21. Error messages expose internal constant names, making cross-branch fakes hard to parse
+
+When multi-ternary fan-out (#17) or joined-range pessimism kicks in, the failure message reads like:
+
+```
+int 92..92 as ((WINDOW_GAP_LEFT + COLLAPSED_NAV_INNER_WIDTH) + EXPANDED_NAV_CONTAINER_GAP) <= int 90..90 as ((((WINDOW_GAP_LEFT + COLLAPSED_NAV_INNER_WIDTH) + COLLAPSED_NAV_CONTAINER_GAP) + 0) + INPUT_INSET_X) is false
+```
+
+The author has to mentally constant-fold and notice that the LHS came from one branch of a ternary while the RHS came from the *other* branch — i.e. that the checker is comparing a combination that can't actually run. Until you've trained yourself to spot this, the message reads like a real bug.
+
+Not a functional limitation — but it's a sharp edge that costs real minutes per occurrence.
+
+**What we want:** When a failure traces to a cross-branch combination, name it as such: "fake combination from discriminator `collapsedNav` (LHS assumes === 1, RHS assumes === 0)". Same information, but framed so the author recognizes the fix (#17) rather than chasing a phantom bug.

--- a/negative-patterns.expected.txt
+++ b/negative-patterns.expected.txt
@@ -716,6 +716,14 @@ FAIL negative-patterns.ts:negativeUnionReturnOutsideSet: return: 40 | 120
   value was int 82..214 as navSizeX, expected one of 40 | 120
   branches produced 82, 214
   missing: navSizeX in {40, 120}
+FAIL negative-patterns.ts:negativeUnionBranchInsideBoundsOutsideSet: return: 0 | 100
+  value was int 0..50, expected one of 0 | 100
+  branches produced 50
+  missing: int 0..50 in {0, 100}
+FAIL negative-patterns.ts:negativeUnionGivenCallerOutsideSet: call negativeUnionGivenCallee(150): requires navSizeX: 82 | 214
+  called function requires navSizeX: 82 | 214
+  this call passes navSizeX = 150
+  missing: navSizeX in {82, 214}
 FAIL negative-patterns.ts:default: return.x: 50..100
   range was -50..150 as (rect.left + ((rect.right - rect.left) / 2)), expected inside 50..100
   need: (rect.left + ((rect.right - rect.left) / 2)) inside 50..100

--- a/negative-patterns.expected.txt
+++ b/negative-patterns.expected.txt
@@ -712,6 +712,10 @@ UNKNOWN negative-patterns.ts:negativeGivenComparisonCannotCallInputMethod: given
   given comparisons only support input paths, numbers, and simple arithmetic
 UNKNOWN negative-patterns.ts:negativeLoopGivenCannotNameRows > loop: given rows.length == items.length
   given can only describe inputs; rows is not an input here
+FAIL negative-patterns.ts:negativeUnionReturnOutsideSet: return: 40 | 120
+  value was int 82..214 as navSizeX, expected one of 40 | 120
+  branches produced 82, 214
+  missing: navSizeX in {40, 120}
 FAIL negative-patterns.ts:default: return.x: 50..100
   range was -50..150 as (rect.left + ((rect.right - rect.left) / 2)), expected inside 50..100
   need: (rect.left + ((rect.right - rect.left) / 2)) inside 50..100

--- a/negative-patterns.ts
+++ b/negative-patterns.ts
@@ -1060,6 +1060,14 @@ export function negativeUnionReturnOutsideSet(navSizeX: number) {
   return navSizeX
 }
 
+// A branch that lands between the union's bounds is still outside the set.
+/** @fit
+ * return: 0 | 100
+ */
+export function negativeUnionBranchInsideBoundsOutsideSet(folder: boolean) {
+  return folder ? 0 : 50
+}
+
 // Hand a literal that is NOT in the union to a callee that requires
 // membership. Freerange rejects the call with the set in the missing line.
 /** @fit
@@ -1070,6 +1078,9 @@ function negativeUnionGivenCallee(navSizeX: number) {
   return navSizeX
 }
 
+/** @fit
+ * return >= 82
+ */
 export function negativeUnionGivenCallerOutsideSet() {
   return negativeUnionGivenCallee(150)
 }

--- a/negative-patterns.ts
+++ b/negative-patterns.ts
@@ -1049,6 +1049,31 @@ export function negativeLoopGivenCannotNameRows(items: number[]) {
 
 export const negativeTopLevelInlineCallGiven = negativeNeedsContainerFit(4, 3) // @fit -1..0
 
+// The return value is known to be one of `{82, 214}`, so `return: 40 | 120`
+// cannot hold. A range-based check would be pessimistic too, but the union
+// check reports the set directly so authors see which values are rejected.
+/** @fit
+ * given navSizeX: 82 | 214
+ * return: 40 | 120
+ */
+export function negativeUnionReturnOutsideSet(navSizeX: number) {
+  return navSizeX
+}
+
+// Hand a literal that is NOT in the union to a callee that requires
+// membership. Freerange rejects the call with the set in the missing line.
+/** @fit
+ * given navSizeX: 82 | 214
+ * return >= 82
+ */
+function negativeUnionGivenCallee(navSizeX: number) {
+  return navSizeX
+}
+
+export function negativeUnionGivenCallerOutsideSet() {
+  return negativeUnionGivenCallee(150)
+}
+
 /** @fit
  * given rect.left: 0..100
  * given rect.right: 0..100

--- a/patterns.ts
+++ b/patterns.ts
@@ -1208,6 +1208,20 @@ export function literalUnionGivenOnParam(
 }
 
 /** @fit
+ * return: 82 | 214
+ */
+export function literalUnionTypedParamPassesThrough(navSizeX: 82 | 214) {
+  return navSizeX
+}
+
+/** @fit
+ * return: 0 | 100
+ */
+export function literalUnionBranchReturn(folder: boolean) {
+  return folder ? 0 : 100
+}
+
+/** @fit
  * given count: int 1..50
  * given focused: int 0..<count
  * return.targetIndex: int 0..49

--- a/patterns.ts
+++ b/patterns.ts
@@ -1013,7 +1013,7 @@ export function pathSensitiveMinOverflow(width: number) {
 // as cases so downstream Math.min can still prove `capped <= width`.
 /** @fit
  * given width: 0..1000
- * result.overflow >= 0
+ * return.overflow >= 0
  */
 export function pathSensitiveMinOverflowTernaryInset(width: number, folder: boolean) {
   const inset = folder ? 108 : 68
@@ -1185,6 +1185,26 @@ export function nestedBranchLocalReturnChecks(focused: number) {
     return 0
   }
   return focused // @fit == 0
+}
+
+// Literal-union `given` narrows the input domain to exactly those values. Each
+// union member flows through as its own case so a downstream fact like
+// `return: 82 | 214` stays provable. The param form (`// @fit 0 | 40 | ...`)
+// and the block form (`given searchSlot: 0 | 40 | ...`) are both accepted.
+/** @fit
+ * given navSizeX: 82 | 214
+ * return: 82 | 214
+ * return >= 82
+ * return <= 214
+ */
+export function literalUnionGivenPassesThrough(navSizeX: number) {
+  return navSizeX
+}
+
+export function literalUnionGivenOnParam(
+  searchSlot: number, // @fit 0 | 40 | 200 | 213
+) {
+  return searchSlot + 14 // @fit 14 | 54 | 214 | 227
 }
 
 /** @fit

--- a/patterns.ts
+++ b/patterns.ts
@@ -1009,6 +1009,18 @@ export function pathSensitiveMinOverflow(width: number) {
   return {capped, overflow}
 }
 
+// Regression: a ternary over two literal numbers must keep per-branch identity
+// as cases so downstream Math.min can still prove `capped <= width`.
+/** @fit
+ * given width: 0..1000
+ * result.overflow >= 0
+ */
+export function pathSensitiveMinOverflowTernaryInset(width: number, folder: boolean) {
+  const inset = folder ? 108 : 68
+  const capped = Math.min(width, inset)
+  return {overflow: width - capped}
+}
+
 /** @fit
  * given width: 0..1000
  * given padding: 0..120

--- a/src/check.ts
+++ b/src/check.ts
@@ -29,6 +29,7 @@ import {
   type FitDomainPathSegment,
   type FitRange,
   type FitSpec,
+  type FitUnion,
 } from './parser.ts'
 import {
   binaryExpr,
@@ -270,6 +271,7 @@ const maxInlineDepth = 12
 
 type TrustedGivenSpec =
   | {kind: 'range'; spec: Extract<FitSpec, {kind: 'given-range'}>; source: Extract<FactSource, 'function-given' | 'loop-given'>}
+  | {kind: 'union'; spec: Extract<FitSpec, {kind: 'given-union'}>; source: Extract<FactSource, 'function-given' | 'loop-given'>}
   | {kind: 'comparison'; spec: Extract<FitSpec, {kind: 'given-comparison'}>; source: Extract<FactSource, 'function-given' | 'loop-given'>}
 
 type ImportedContractSource = {
@@ -373,7 +375,7 @@ function doctorFunctionCalls(program: Program, fn: FitFunction, contractCache: M
 
   const {trustedGivens} = validateGivenSpecs(program.file, functionName, specs, inputRoots, 'function-given')
   for (const given of trustedGivens) {
-    if (given.kind === 'range') applyGivenRangeSpec(env, given.spec)
+    applyTrustedGiven(env, given)
   }
   const {assumptions} = collectGivenAssumptions(program.file, program, functionName, env, inputRoots, trustedGivens, contractCache)
   const context: EvalContext = {
@@ -488,10 +490,7 @@ function verifyFunctionSpecs(
 
   const {trustedGivens, checks} = validateGivenSpecs(file, functionName, specs, inputRoots, 'function-given')
 
-  for (const given of trustedGivens) {
-    if (given.kind !== 'range') continue
-    applyGivenRangeSpec(env, given.spec)
-  }
+  for (const given of trustedGivens) applyTrustedGiven(env, given)
 
   const {assumptions, checks: impossibleChecks} = collectGivenAssumptions(file, program, functionName, env, inputRoots, trustedGivens, contractCache)
   checks.push(...impossibleChecks)
@@ -511,15 +510,19 @@ function verifyFunctionSpecs(
   if (hasBodyClaims) checks.push(...context.checks)
 
   for (const spec of specs) {
-    if (spec.kind === 'given-range' || spec.kind === 'given-comparison') continue
+    if (isGivenSpec(spec)) continue
     checks.push(verifyCheckSpec(file, program, functionName, env, result, spec, checks, context.assumptions, contractCache))
   }
 
   return checks
 }
 
+function isGivenSpec(spec: FitSpec): spec is Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}> {
+  return spec.kind === 'given-range' || spec.kind === 'given-union' || spec.kind === 'given-comparison'
+}
+
 function functionHasBodyClaims(specs: FitSpec[]) {
-  return specs.some(spec => spec.kind !== 'given-range' && spec.kind !== 'given-comparison')
+  return specs.some(spec => !isGivenSpec(spec))
 }
 
 function inferFunctionFacts(program: Program, fn: FitFunction, contractCache: Map<string, FunctionContractProof>): FitInferFunctionReport {
@@ -533,7 +536,7 @@ function inferFunctionFacts(program: Program, fn: FitFunction, contractCache: Ma
 
   const {trustedGivens, checks: givenChecks} = validateGivenSpecs(program.file, functionName, specs, inputRoots, 'function-given')
   for (const given of trustedGivens) {
-    if (given.kind === 'range') applyGivenRangeSpec(env, given.spec)
+    applyTrustedGiven(env, given)
   }
   const {assumptions, checks} = collectGivenAssumptions(program.file, program, functionName, env, inputRoots, trustedGivens, contractCache)
   const inferUnsupported: string[] = []
@@ -607,7 +610,7 @@ function evaluateFunctionShapeState(program: Program, fn: FitFunction, contractC
 
   const {trustedGivens} = validateGivenSpecs(program.file, functionName, specs, inputRoots, 'function-given')
   for (const given of trustedGivens) {
-    if (given.kind === 'range') applyGivenRangeSpec(env, given.spec)
+    applyTrustedGiven(env, given)
   }
   const {assumptions} = collectGivenAssumptions(program.file, program, functionName, env, inputRoots, trustedGivens, contractCache)
   const context: EvalContext = {program, file: program.file, env, inputRoots, stack: [functionName], checks: [], assumptions, contractCache}
@@ -774,7 +777,7 @@ function inferFunctionSpecReports(
   }
 
   return specs.map(spec => {
-    if (spec.kind === 'given-range' || spec.kind === 'given-comparison') {
+    if (isGivenSpec(spec)) {
       const check = checkByText.get(spec.text)
       if (check == null || check.status === 'pass') return {text: spec.text, status: 'trusted'}
       return {text: spec.text, status: 'not-inferred', reason: check.reason ?? check.status}
@@ -802,9 +805,10 @@ function inferredFactReasonForSpecText(specText: string, facts: FitInferFact[]) 
   if (exactFact != null) return exactFact.text
 
   const spec = parseFitSpecLineForInference(specText)
-  if (spec == null || spec.kind === 'given-range' || spec.kind === 'given-comparison') return null
+  if (spec == null || isGivenSpec(spec)) return null
   if (spec.kind === 'check-atom') return null
   if (spec.kind === 'check-range') return rangeFactReasonForSpec(spec, facts)
+  if (spec.kind === 'check-union') return unionFactReasonForSpec(spec, facts)
   return comparisonFactReasonForSpec(spec, facts)
 }
 
@@ -856,6 +860,18 @@ function comparisonFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-compar
     case '==':
       return equalityFactReasonForSpec(spec, facts)
   }
+}
+
+function unionFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-union'}>, facts: FitInferFact[]) {
+  const range = inferredRangeFactForExpression(facts, spec.expression)
+  if (range == null) return null
+  const unionMin = Math.min(...spec.union.values)
+  const unionMax = Math.max(...spec.union.values)
+  // A redundant union fact needs an existing range fact that fits strictly
+  // inside the declared union bounds. We do not try to match cases here yet;
+  // range coverage is the safest lower-bound guess.
+  if (range.min >= unionMin && range.max <= unionMax) return range.text
+  return null
 }
 
 function equalityFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-comparison'}>, facts: FitInferFact[]) {
@@ -1054,7 +1070,7 @@ function validateGivenSpecs(
   const ranges: Extract<FitSpec, {kind: 'given-range'}>[] = []
 
   for (const spec of specs) {
-    if (spec.kind !== 'given-range' && spec.kind !== 'given-comparison') continue
+    if (!isGivenSpec(spec)) continue
     const badRoot = givenBadRoot(spec, allowedRoots)
     if (badRoot != null) {
       checks.push(invalidGivenCheck(file, functionName, spec, `given can only describe inputs; ${publicFitText(badRoot)} is not an input here`))
@@ -1077,20 +1093,25 @@ function validateGivenSpecs(
       continue
     }
 
+    if (spec.kind === 'given-union') {
+      trustedGivens.push({kind: 'union', spec, source})
+      continue
+    }
+
     trustedGivens.push({kind: 'comparison', spec, source})
   }
 
   return {trustedGivens, checks}
 }
 
-function givenBadRoot(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}>, allowedRoots: string[]): string | null {
+function givenBadRoot(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}>, allowedRoots: string[]): string | null {
   for (const root of givenRootNames(spec)) {
     if (!allowedRoots.includes(root)) return root
   }
   return null
 }
 
-function givenRootNames(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}>): string[] {
+function givenRootNames(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}>): string[] {
   switch (spec.kind) {
     case 'given-range':
       return [...new Set([
@@ -1098,6 +1119,8 @@ function givenRootNames(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'g
         ...rangeBoundRootNames(spec.range.lower),
         ...rangeBoundRootNames(spec.range.upper),
       ])]
+    case 'given-union':
+      return expressionRootNamesFromText(spec.expression)
     case 'given-comparison':
       return [...new Set([...expressionRootNamesFromText(spec.left), ...expressionRootNamesFromText(spec.right)])]
   }
@@ -1134,7 +1157,7 @@ function closedRangeApprox(range: FitRange): {min: number; max: number} | null {
   return {min, max}
 }
 
-function givenShapeProblem(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}>): string | null {
+function givenShapeProblem(spec: Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}>): string | null {
   const roots = givenRootNames(spec)
   if (roots.length === 0) return 'given must mention an input'
 
@@ -1146,6 +1169,14 @@ function givenShapeProblem(spec: Extract<FitSpec, {kind: 'given-range'} | {kind:
     const lower = givenComparisonExpressionProblem(spec.range.lower)
     if (lower != null) return lower
     return givenComparisonExpressionProblem(spec.range.upper)
+  }
+
+  if (spec.kind === 'given-union') {
+    if (parseDomainPathText(spec.expression) == null) {
+      const expression = parseExpression(spec.expression)
+      if (!isGivenRangeExpression(expression)) return 'given union must name one input path, not a derived expression'
+    }
+    return null
   }
 
   const left = givenComparisonExpressionProblem(spec.left)
@@ -1219,6 +1250,20 @@ function collectGivenAssumptions(
       const upper = evaluateRangeBound(spec.range.upper, context)
       if (lower.kind !== 'number' || upper.kind !== 'number') continue
       assumptions.push(...rangeFactsFromBounds(value, lower, spec.range.lowerInclusive, upper, spec.range.upperInclusive, spec.text, given.source))
+      continue
+    }
+
+    if (given.kind === 'union') {
+      // A union `x: 0 | 40 | 200` also gives the linear solver the
+      // [min..max] closure — downstream `x >= 0` style checks still work.
+      const spec = given.spec
+      const value = evaluateSpecExpression(spec.expression, context)
+      if (value.kind !== 'number') continue
+      const min = Math.min(...spec.union.values)
+      const max = Math.max(...spec.union.values)
+      const lower = numberValue(min, min, Number.isInteger(min), `${min}`, linearConstant(min))
+      const upper = numberValue(max, max, Number.isInteger(max), `${max}`, linearConstant(max))
+      assumptions.push(...rangeFactsFromBounds(value, lower, true, upper, true, spec.text, given.source))
       continue
     }
 
@@ -1323,6 +1368,11 @@ function positiveTermCancelScale(left: LinearExpr, right: LinearExpr): number | 
   return scale
 }
 
+function applyTrustedGiven(env: Map<string, Value>, given: TrustedGivenSpec) {
+  if (given.kind === 'range') applyGivenRangeSpec(env, given.spec)
+  else if (given.kind === 'union') applyGivenUnionSpec(env, given.spec)
+}
+
 function applyGivenRangeSpec(env: Map<string, Value>, spec: Extract<FitSpec, {kind: 'given-range'}>) {
   const closed = closedRangeApprox(spec.range)
   const value = numberValue(
@@ -1332,15 +1382,43 @@ function applyGivenRangeSpec(env: Map<string, Value>, spec: Extract<FitSpec, {ki
     spec.expression,
     linearVariable(linearNameForExpression(spec.expression)),
   )
-  if (spec.expression.includes('[]')) {
-    const domainPath = parseDomainPathText(spec.expression)
+  writeGivenValueToEnv(env, spec.expression, value)
+}
+
+// A literal-union `given x: 0 | 40 | 200` binds the input value to a NumberValue
+// whose min/max cover the union AND whose `cases` enumerate each literal. This
+// lets Math.min / subtraction see each concrete branch (see `joinValues`) while
+// keeping downstream range math honest.
+function applyGivenUnionSpec(env: Map<string, Value>, spec: Extract<FitSpec, {kind: 'given-union'}>) {
+  const value = numberValueFromUnion(spec.union, spec.expression)
+  writeGivenValueToEnv(env, spec.expression, value)
+}
+
+function numberValueFromUnion(union: FitUnion, expression: string): NumberValue {
+  const min = Math.min(...union.values)
+  const max = Math.max(...union.values)
+  const isInteger = union.valueKind === 'int' || union.values.every(Number.isInteger)
+  const linear = linearVariable(linearNameForExpression(expression))
+  const cases: NumberCase[] = union.values.map(literal => ({
+    value: numberValue(literal, literal, Number.isInteger(literal), `${literal}`, linearConstant(literal)),
+    assumptions: [],
+  }))
+  return withNumberCases(
+    numberValue(min, max, isInteger, expression, linear),
+    cases,
+  )
+}
+
+function writeGivenValueToEnv(env: Map<string, Value>, expressionText: string, value: NumberValue) {
+  if (expressionText.includes('[]')) {
+    const domainPath = parseDomainPathText(expressionText)
     if (domainPath != null && domainPath.segments.length > 0) {
       env.set(domainPath.root, setDomainPathValue(env.get(domainPath.root), domainPath.root, domainPath.segments, value))
     }
     return
   }
 
-  const expression = parseExpression(spec.expression)
+  const expression = parseExpression(expressionText)
   if (ts.isIdentifier(expression)) {
     env.set(expression.text, value)
     return
@@ -1353,7 +1431,7 @@ function applyGivenRangeSpec(env: Map<string, Value>, spec: Extract<FitSpec, {ki
     return
   }
 
-  const domainPath = parseDomainPathText(spec.expression)
+  const domainPath = parseDomainPathText(expressionText)
   if (domainPath == null || domainPath.segments.length === 0) return
   env.set(domainPath.root, setDomainPathValue(env.get(domainPath.root), domainPath.root, domainPath.segments, value))
 }
@@ -1375,7 +1453,7 @@ function unknownResultValue(specs: FitSpec[], program: Program): Value {
 function specParamShape(name: string, specs: FitSpec[]): 'array' | 'object' | 'number' {
   let shape: 'object' | 'number' = 'number'
   for (const spec of specs) {
-    if (spec.kind === 'given-range' || spec.kind === 'check-range') {
+    if (spec.kind === 'given-range' || spec.kind === 'check-range' || spec.kind === 'given-union' || spec.kind === 'check-union') {
       const next = specExpressionParamShape(spec.expression, name)
       if (next === 'array') return 'array'
       if (next === 'object') shape = 'object'
@@ -1537,7 +1615,7 @@ function verifyCheckSpec(
   functionName: string,
   baseEnv: Map<string, Value>,
   result: Value,
-  spec: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'} | {kind: 'check-atom'}>,
+  spec: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'} | {kind: 'check-atom'}>,
   checks: FitCheck[],
   assumptions: LinearConstraint[],
   contractCache: Map<string, FunctionContractProof>,
@@ -1562,6 +1640,19 @@ function verifyCheckSpec(
     }
     const value = evaluateSpecExpression(spec.expression, context)
     const status = proveRangeSpec(value, spec.range, context)
+    return {
+      file,
+      ...(spec.line == null ? {} : {line: spec.line}),
+      functionName,
+      text: spec.text,
+      status: status.status,
+      ...(status.reason == null ? {} : {reason: status.reason}),
+    }
+  }
+
+  if (spec.kind === 'check-union') {
+    const value = evaluateSpecExpression(spec.expression, context)
+    const status = proveUnionSpec(value, spec.union)
     return {
       file,
       ...(spec.line == null ? {} : {line: spec.line}),
@@ -1605,6 +1696,71 @@ function verifyCheckSpec(
     status: status.status,
     ...(reason == null ? {} : {reason}),
   }
+}
+
+// Prove that a value is a member of a literal-union `{v1, v2, ...}`. Two
+// good-enough signals:
+// 1. The value has `cases`, and every case collapses to a union member. This
+//    is the common path when the callee's `given` bound the parameter, or when
+//    a branchy local (e.g. `flag ? 82 : 214`) produced discrete cases.
+// 2. The value is a literal constant (min == max == literal) that lives in the
+//    set.
+// Anything wider than the union is an honest `unknown`/`fail`, not a pass.
+function proveUnionSpec(value: Value, union: FitUnion): {status: FitCheckStatus; reason?: string} {
+  if (value.kind !== 'number') return {status: 'unknown', reason: expectedNumberReason(value)}
+  const set = new Set(union.values)
+  const unionMin = Math.min(...union.values)
+  const unionMax = Math.max(...union.values)
+  const intCheck = union.valueKind === 'int' && !value.isInteger ? `${exprOrRange(value)} to be integer` : null
+
+  if (value.cases != null) {
+    const missing: number[] = []
+    for (const branch of value.cases) {
+      const point = branch.value.min === branch.value.max ? branch.value.min : null
+      if (point == null || !set.has(point)) missing.push(point ?? Number.NaN)
+    }
+    if (missing.length === 0 && intCheck == null) return {status: 'pass'}
+    if (missing.length > 0) {
+      return {
+        status: outsideFailStatus(value.min, value.max, unionMin, unionMax),
+        reason: unionFailureReason(value, union, `branches produced ${missing.filter(Number.isFinite).join(', ') || 'non-literal values'}`),
+      }
+    }
+    return {status: 'fail', reason: unionFailureReason(value, union, intCheck ?? 'integer check failed')}
+  }
+
+  if (value.min === value.max && Number.isFinite(value.min)) {
+    if (set.has(value.min) && intCheck == null) return {status: 'pass'}
+    // A known literal that is not in the set is an honest fail regardless of
+    // whether it sits between the union's min and max.
+    return {status: 'fail', reason: unionFailureReason(value, union, null)}
+  }
+
+  return {
+    status: outsideFailStatus(value.min, value.max, unionMin, unionMax),
+    reason: unionFailureReason(value, union, null),
+  }
+}
+
+function outsideFailStatus(min: number, max: number, unionMin: number, unionMax: number): FitCheckStatus {
+  return min < unionMin || max > unionMax ? 'fail' : 'unknown'
+}
+
+function unionFailureReason(value: NumberValue, union: FitUnion, detail: string | null): string {
+  const lines = [
+    `value was ${formatRange(value)}, expected one of ${formatUnionSpec(union)}`,
+  ]
+  if (detail != null) lines.push(detail)
+  lines.push(`missing: ${exprOrRange(value)} in {${union.values.join(', ')}}`)
+  return lines.join('\n')
+}
+
+function exprOrRange(value: NumberValue): string {
+  return value.expr == null ? formatRange(value) : publicFitText(value.expr)
+}
+
+export function formatUnionSpec(union: FitUnion): string {
+  return union.values.join(' | ')
 }
 
 function proveRangeSpec(value: Value, range: FitRange, context: EvalContext): {status: FitCheckStatus; reason?: string} {
@@ -1922,7 +2078,7 @@ function bindVariableStatement(statement: ts.VariableStatement, context: EvalCon
   verifyLocalFitSpecs(specs, context)
 }
 
-function verifyLocalFitSpecs(specs: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}>[], context: EvalContext) {
+function verifyLocalFitSpecs(specs: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}>[], context: EvalContext) {
   if (specs.length === 0) return
   for (const spec of specs) {
     context.checks.push(verifyCheckSpec(
@@ -2661,7 +2817,7 @@ function inferLoopSpecReports(specs: FitSpec[], checks: FitCheck[]): FitInferLoo
 
   return specs.map(spec => {
     const check = checkByText.get(spec.text)
-    if (spec.kind === 'given-range' || spec.kind === 'given-comparison') {
+    if (isGivenSpec(spec)) {
       if (check == null || check.status === 'pass') return {text: spec.text, status: 'trusted'}
       return {text: spec.text, status: 'not-inferred', reason: check.reason ?? check.status}
     }
@@ -2710,6 +2866,8 @@ function specExpressionTexts(spec: FitSpec): string[] {
   switch (spec.kind) {
     case 'given-range':
     case 'check-range':
+    case 'given-union':
+    case 'check-union':
       return [spec.expression]
     case 'given-comparison':
     case 'check-comparison':
@@ -2738,10 +2896,7 @@ function applyLocalGivenSpecs(specs: FitSpec[], context: EvalContext) {
   const {trustedGivens, checks} = validateGivenSpecs(context.file, functionName, specs, context.inputRoots, 'loop-given')
   context.checks.push(...checks)
 
-  for (const given of trustedGivens) {
-    if (given.kind !== 'range') continue
-    applyGivenRangeSpec(context.env, given.spec)
-  }
+  for (const given of trustedGivens) applyTrustedGiven(context.env, given)
   const {assumptions, checks: impossibleChecks} = collectGivenAssumptions(
     context.file,
     context.program,
@@ -2760,7 +2915,7 @@ function verifyLocalLoopSpecs(specs: FitSpec[], context: EvalContext) {
   const functionName = `${context.stack.at(-1) ?? '<unknown>'} > loop`
   const loopResult = unknown('Loop annotations do not have return; name local values directly')
   for (const spec of specs) {
-    if (spec.kind === 'given-range' || spec.kind === 'given-comparison') continue
+    if (isGivenSpec(spec)) continue
     context.checks.push(verifyCheckSpec(
       context.file,
       context.program,
@@ -3485,6 +3640,7 @@ function valueWithFunctionContractSummary(
 
   for (const spec of specs) {
     if (spec.kind === 'check-range') applySummaryRangeSpec(env, spec, source)
+    if (spec.kind === 'check-union') applySummaryUnionSpec(env, spec, source)
   }
   for (const spec of specs) {
     if (spec.kind === 'check-comparison') applySummaryComparisonSpec(env, spec, context, source)
@@ -3509,6 +3665,20 @@ function applySummaryRangeSpec(env: Map<string, Value>, spec: Extract<FitSpec, {
       null,
       [sourceProvedContractFact(source, spec.text)],
     ),
+  )
+}
+
+// A caller consuming a `return: 82 | 214` contract should see the returned
+// value as a narrowed NumberValue with per-literal cases. That keeps the
+// discrete identity around for downstream Math.min / subtraction the same way
+// source-proved `joinValues` preserves cases.
+function applySummaryUnionSpec(env: Map<string, Value>, spec: Extract<FitSpec, {kind: 'check-union'}>, source: FunctionContractSource) {
+  if (simpleResultPathText(spec.expression) == null) return
+  const base = numberValueFromUnion(spec.union, spec.expression)
+  setSummaryPathValue(
+    env,
+    spec.expression,
+    {...base, provenance: [sourceProvedContractFact(source, spec.text)]},
   )
 }
 
@@ -3645,6 +3815,11 @@ function verifyCallGivenSpecs(
       status = proveRangeSpec(value, spec.range, calleeContext)
       if (status.status !== 'pass') status = withCallRangeReason(status, value, spec)
     }
+    if (spec.kind === 'given-union') {
+      const value = evaluateSpecExpression(spec.expression, calleeContext)
+      status = proveUnionSpec(value, spec.union)
+      if (status.status !== 'pass') status = withCallUnionReason(status, value, spec)
+    }
     if (spec.kind === 'given-comparison') {
       const left = evaluateSpecExpression(spec.left, calleeContext)
       const right = evaluateSpecExpression(spec.right, calleeContext)
@@ -3684,6 +3859,22 @@ function withCallRangeReason(
       `called function requires ${spec.expression}: ${formatRangeSpec(spec.range)}`,
       `this call passes ${formatCallBinding(spec.expression, value)}`,
       ...missingBoundsForRange(value, spec.range),
+    ].join('\n'),
+  }
+}
+
+function withCallUnionReason(
+  status: {status: FitCheckStatus; reason?: string},
+  value: Value,
+  spec: Extract<FitSpec, {kind: 'given-union'}>,
+): {status: FitCheckStatus; reason?: string} {
+  if (value.kind !== 'number') return status
+  return {
+    ...status,
+    reason: [
+      `called function requires ${spec.expression}: ${formatUnionSpec(spec.union)}`,
+      `this call passes ${formatCallBinding(spec.expression, value)}`,
+      `missing: ${spec.expression} in {${spec.union.values.join(', ')}}`,
     ].join('\n'),
   }
 }
@@ -4042,12 +4233,14 @@ function objectPathText(path: string[] | undefined) {
   return path == null || path.length === 0 ? '<property>' : path.join('.')
 }
 
-function verifyInlineSpecsForValue(specs: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}>[], value: Value, context: EvalContext) {
+function verifyInlineSpecsForValue(specs: Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}>[], value: Value, context: EvalContext) {
   if (specs.length === 0) return
   for (const spec of specs) {
     const status = spec.kind === 'check-range'
       ? proveRangeSpec(value, spec.range, context)
-      : proveInlineComparisonSpec(value, spec, context)
+      : spec.kind === 'check-union'
+        ? proveUnionSpec(value, spec.union)
+        : proveInlineComparisonSpec(value, spec, context)
     context.checks.push({
       file: context.file,
       ...(spec.line == null ? {} : {line: spec.line}),

--- a/src/check.ts
+++ b/src/check.ts
@@ -865,13 +865,9 @@ function comparisonFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-compar
 function unionFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-union'}>, facts: FitInferFact[]) {
   const range = inferredRangeFactForExpression(facts, spec.expression)
   if (range == null) return null
-  const unionMin = Math.min(...spec.union.values)
-  const unionMax = Math.max(...spec.union.values)
-  // A redundant union fact needs an existing range fact that fits strictly
-  // inside the declared union bounds. We do not try to match cases here yet;
-  // range coverage is the safest lower-bound guess.
-  if (range.min >= unionMin && range.max <= unionMax) return range.text
-  return null
+  if (range.min !== range.max) return null
+  if (spec.union.valueKind === 'int' && !range.isInteger) return null
+  return spec.union.values.includes(range.min) ? range.text : null
 }
 
 function equalityFactReasonForSpec(spec: Extract<FitSpec, {kind: 'check-comparison'}>, facts: FitInferFact[]) {
@@ -1711,7 +1707,6 @@ function proveUnionSpec(value: Value, union: FitUnion): {status: FitCheckStatus;
   const set = new Set(union.values)
   const unionMin = Math.min(...union.values)
   const unionMax = Math.max(...union.values)
-  const intCheck = union.valueKind === 'int' && !value.isInteger ? `${exprOrRange(value)} to be integer` : null
 
   if (value.cases != null) {
     const missing: number[] = []
@@ -1719,26 +1714,25 @@ function proveUnionSpec(value: Value, union: FitUnion): {status: FitCheckStatus;
       const point = branch.value.min === branch.value.max ? branch.value.min : null
       if (point == null || !set.has(point)) missing.push(point ?? Number.NaN)
     }
-    if (missing.length === 0 && intCheck == null) return {status: 'pass'}
-    if (missing.length > 0) {
-      return {
-        status: outsideFailStatus(value.min, value.max, unionMin, unionMax),
-        reason: unionFailureReason(value, union, `branches produced ${missing.filter(Number.isFinite).join(', ') || 'non-literal values'}`),
-      }
+    if (missing.length === 0) return {status: 'pass'}
+    const missingLiterals = missing.filter(Number.isFinite)
+    return {
+      status: missingLiterals.length > 0 ? 'fail' : outsideFailStatus(value.min, value.max, unionMin, unionMax),
+      reason: unionFailureReason(value, union, `branches produced ${missingLiterals.join(', ') || 'non-literal values'}`),
     }
-    return {status: 'fail', reason: unionFailureReason(value, union, intCheck ?? 'integer check failed')}
   }
 
   if (value.min === value.max && Number.isFinite(value.min)) {
-    if (set.has(value.min) && intCheck == null) return {status: 'pass'}
+    if (set.has(value.min)) return {status: 'pass'}
     // A known literal that is not in the set is an honest fail regardless of
     // whether it sits between the union's min and max.
     return {status: 'fail', reason: unionFailureReason(value, union, null)}
   }
 
+  const intCheck = union.valueKind === 'int' && !value.isInteger ? `${exprOrRange(value)} to be integer` : null
   return {
     status: outsideFailStatus(value.min, value.max, unionMin, unionMax),
-    reason: unionFailureReason(value, union, null),
+    reason: unionFailureReason(value, union, intCheck),
   }
 }
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -408,16 +408,22 @@ export function joinValues(left: Value, right: Value): Value {
   if (left.kind === 'unknown') return left
   if (right.kind === 'unknown') return right
   if (left.kind === 'number' && right.kind === 'number') {
+    const sameExpr = left.expr != null && right.expr != null && left.expr === right.expr
+    const sameLin = left.linear != null && right.linear != null && sameLinear(left.linear, right.linear)
     const joined = numberValue(
       Math.min(left.min, right.min),
       Math.max(left.max, right.max),
       left.isInteger && right.isInteger,
-      left.expr != null && right.expr != null && left.expr === right.expr ? left.expr : null,
-      left.linear != null && right.linear != null && sameLinear(left.linear, right.linear) ? left.linear : null,
+      sameExpr ? left.expr : null,
+      sameLin ? left.linear : null,
       null,
       mergeProvenance(left, right),
     )
-    if (left.cases == null && right.cases == null) return joined
+    // If the two branches carry the exact same value (same linear/expr), a plain
+    // range join is enough. When they disagree — e.g. `flag ? 108 : 68` — we
+    // preserve per-branch identity as cases so downstream Math.min / subtraction
+    // can still see which literal the value collapses to on each branch.
+    if (left.cases == null && right.cases == null && sameLin) return joined
     return withNumberCases(joined, [...numberBranches(left), ...numberBranches(right)])
   }
   if (left.kind === 'object' && right.kind === 'object') {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -25,11 +25,29 @@ export type FitRange = {
   text: string
 }
 
+// A literal-union domain like `0 | 40 | 200 | 213`. Values are the discrete
+// numeric literals parsed out of the `|` list. Used by `given` to describe
+// inputs and by inline/return `@fit` to claim membership in the same small
+// set. This is the `cases` view of a domain — we do not widen it to a range
+// except as a secondary approximation for downstream linear math.
+export type FitUnion = {
+  valueKind: 'int' | 'number'
+  values: number[]
+  text: string
+}
+
 export type FitSpec =
   | {
       kind: 'given-range'
       expression: string
       range: FitRange
+      text: string
+      line?: number
+    }
+  | {
+      kind: 'given-union'
+      expression: string
+      union: FitUnion
       text: string
       line?: number
     }
@@ -45,6 +63,13 @@ export type FitSpec =
       kind: 'check-range'
       expression: string
       range: FitRange
+      text: string
+      line?: number
+    }
+  | {
+      kind: 'check-union'
+      expression: string
+      union: FitUnion
       text: string
       line?: number
     }
@@ -115,7 +140,7 @@ export function parseFunctionFitSpecs(
   ]
 }
 
-export function parseParamFitSpecs(sourceText: string, param: ts.ParameterDeclaration): Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}>[] {
+export function parseParamFitSpecs(sourceText: string, param: ts.ParameterDeclaration): Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}>[] {
   const lines = inlineFitCommentLines(sourceText, param)
   if (lines.length === 0) return []
   if (!ts.isIdentifier(param.name)) throw new Error('Param @fit comments support simple identifier parameters')
@@ -131,7 +156,7 @@ export function hasInlineFitComment(sourceText: string, node: ts.Node): boolean 
   return inlineFitCommentLines(sourceText, node).length > 0
 }
 
-export function parseLocalFitSpecs(sourceText: string, statement: ts.VariableStatement): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}>[] {
+export function parseLocalFitSpecs(sourceText: string, statement: ts.VariableStatement): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}>[] {
   const lines = inlineFitCommentLines(sourceText, statement)
   if (lines.length === 0) return []
   const declarations = statement.declarationList.declarations
@@ -142,7 +167,7 @@ export function parseLocalFitSpecs(sourceText: string, statement: ts.VariableSta
   return lines.map(line => parseInlineFitSpecLine(line.text, expression, undefined, line.line))
 }
 
-export function parseInlineFitSpecsForExpression(sourceText: string, node: ts.Node, expression: string): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}>[] {
+export function parseInlineFitSpecsForExpression(sourceText: string, node: ts.Node, expression: string): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}>[] {
   return inlineFitCommentLines(sourceText, node).map(line => parseInlineFitSpecLine(line.text, expression, undefined, line.line))
 }
 
@@ -221,11 +246,30 @@ function lineNumberAtPosition(sourceText: string, position: number) {
 const numberPattern = '-?\\d+(?:\\.\\d+)?'
 const rangeNumberPattern = new RegExp(`^(?:${numberPattern}|-?Infinity)$`)
 
+function parseRangeBoundNumber(text: string): number | null {
+  if (text === 'Infinity') return Number.POSITIVE_INFINITY
+  if (text === '-Infinity') return Number.NEGATIVE_INFINITY
+  const value = Number(text)
+  return Number.isFinite(value) ? value : null
+}
+
 export function parseFitSpecLine(line: string, lineNumber?: number): FitSpec {
   const givenRange = /^given\s+(.+)\s*:\s*(.+)$/.exec(line)
   if (givenRange != null) {
     const expression = normalizeFitText(givenRange[1]!.trim())
-    const range = parseRangeText(givenRange[2]!.trim())
+    const body = givenRange[2]!.trim()
+    const union = parseUnionText(body)
+    if (union != null) {
+      parseExpression(expression)
+      return {
+        kind: 'given-union',
+        expression,
+        union,
+        text: line,
+        ...(lineNumber == null ? {} : {line: lineNumber}),
+      }
+    }
+    const range = parseRangeText(body)
     if (range == null) throw new Error(`Unsupported @fit range: ${line}`)
     parseExpression(expression)
     return {
@@ -256,7 +300,19 @@ export function parseFitSpecLine(line: string, lineNumber?: number): FitSpec {
   const checkRange = /^(.+)\s*:\s*(.+)$/.exec(line)
   if (checkRange != null) {
     const expression = normalizeFitText(checkRange[1]!.trim())
-    const range = parseRangeText(checkRange[2]!.trim())
+    const body = checkRange[2]!.trim()
+    const union = parseUnionText(body)
+    if (union != null) {
+      parseExpression(expression)
+      return {
+        kind: 'check-union',
+        expression,
+        union,
+        text: line,
+        ...(lineNumber == null ? {} : {line: lineNumber}),
+      }
+    }
+    const range = parseRangeText(body)
     if (range == null) throw new Error(`Unsupported @fit range: ${line}`)
     parseExpression(expression)
     return {
@@ -288,6 +344,63 @@ export function parseFitSpecLine(line: string, lineNumber?: number): FitSpec {
   if (checkAtom != null) return checkAtom
 
   throw new Error(`Unsupported @fit line: ${line}`)
+}
+
+// A union literal like `0 | 40 | 200 | 213` — a `|`-separated list of at least
+// two numeric literals. A single number is not a union; it's the range-shorthand
+// `2` meaning `2..2`. Returning null here falls through to `parseRangeText`.
+// The `int` prefix is not accepted because literal unions are already discrete;
+// the integer-ness comes from the literals themselves.
+export function parseUnionText(text: string): FitUnion | null {
+  if (!text.includes('|')) return null
+  const parts = splitUnionParts(text)
+  if (parts == null || parts.length < 2) return null
+  const values: number[] = []
+  for (const part of parts) {
+    const parsed = parseRangeBoundNumber(part)
+    if (parsed == null || !Number.isFinite(parsed)) return null
+    values.push(parsed)
+  }
+  const unique = [...new Set(values)].sort((a, b) => a - b)
+  return {
+    valueKind: unique.every(Number.isInteger) ? 'int' : 'number',
+    values: unique,
+    text,
+  }
+}
+
+function splitUnionParts(text: string): string[] | null {
+  let parenDepth = 0
+  let bracketDepth = 0
+  let braceDepth = 0
+  let quote: '"' | "'" | '`' | null = null
+  const parts: string[] = []
+  let start = 0
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+    if (quote != null) {
+      if (char === '\\') i++
+      else if (char === quote) quote = null
+      continue
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '(') parenDepth++
+    else if (char === ')') parenDepth--
+    else if (char === '[') bracketDepth++
+    else if (char === ']') bracketDepth--
+    else if (char === '{') braceDepth++
+    else if (char === '}') braceDepth--
+    else if (char === '|' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0 && text[i + 1] !== '|' && text[i - 1] !== '|') {
+      parts.push(text.slice(start, i).trim())
+      start = i + 1
+    }
+  }
+  parts.push(text.slice(start).trim())
+  if (parts.some(part => part.length === 0)) return null
+  return parts
 }
 
 function parseRangeText(text: string): FitRange | null {
@@ -366,14 +479,14 @@ function splitRangeBounds(text: string): {lower: string; upper: string; upperInc
   return null
 }
 
-function parseInlineFitSpecLine(line: string, expression: string, kind?: 'check-range', lineNumber?: number): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}>
-function parseInlineFitSpecLine(line: string, expression: string, kind: 'given-range', lineNumber?: number): Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}>
+function parseInlineFitSpecLine(line: string, expression: string, kind?: 'check-range', lineNumber?: number): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}>
+function parseInlineFitSpecLine(line: string, expression: string, kind: 'given-range', lineNumber?: number): Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}>
 function parseInlineFitSpecLine(
   line: string,
   expression: string,
   kind: 'check-range' | 'given-range' = 'check-range',
   lineNumber?: number,
-): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-comparison'}> | Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-comparison'}> {
+): Extract<FitSpec, {kind: 'check-range'} | {kind: 'check-union'} | {kind: 'check-comparison'}> | Extract<FitSpec, {kind: 'given-range'} | {kind: 'given-union'} | {kind: 'given-comparison'}> {
   const body = line.slice('@fit'.length).trim()
   const normalizedExpression = normalizeFitText(expression)
   const publicExpression = publicFitText(expression)
@@ -401,12 +514,32 @@ function parseInlineFitSpecLine(
       ...(lineNumber == null ? {} : {line: lineNumber}),
     }
   }
+  const union = parseUnionText(body)
+  if (union != null) {
+    parseExpression(normalizedExpression)
+    if (kind === 'given-range') {
+      return {
+        kind: 'given-union',
+        expression: normalizedExpression,
+        union,
+        text: `given ${publicExpression}: ${publicFitText(body)}`,
+        ...(lineNumber == null ? {} : {line: lineNumber}),
+      }
+    }
+    return {
+      kind: 'check-union',
+      expression: normalizedExpression,
+      union,
+      text: `${publicExpression}: ${publicFitText(body)}`,
+      ...(lineNumber == null ? {} : {line: lineNumber}),
+    }
+  }
   const range = parseRangeText(body)
   if (range == null) throw new Error(`Unsupported inline @fit range: ${line}`)
   parseExpression(normalizedExpression)
   if (kind === 'given-range') {
     return {
-      kind,
+      kind: 'given-range',
       expression: normalizedExpression,
       range,
       text: `given ${publicExpression}: ${publicFitText(body)}`,
@@ -414,7 +547,7 @@ function parseInlineFitSpecLine(
     }
   }
   return {
-    kind,
+    kind: 'check-range',
     expression: normalizedExpression,
     range,
     text: `${publicExpression}: ${publicFitText(body)}`,
@@ -430,13 +563,6 @@ function isRangeBoundText(text: string) {
   } catch {
     return false
   }
-}
-
-function parseRangeBoundNumber(text: string): number | null {
-  if (text === 'Infinity') return Number.POSITIVE_INFINITY
-  if (text === '-Infinity') return Number.NEGATIVE_INFINITY
-  const value = Number(text)
-  return Number.isFinite(value) ? value : null
 }
 
 function parseCheckAtom(line: string, lineNumber?: number): Extract<FitSpec, {kind: 'check-atom'}> | null {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -353,8 +353,11 @@ export function parseFitSpecLine(line: string, lineNumber?: number): FitSpec {
 // the integer-ness comes from the literals themselves.
 export function parseUnionText(text: string): FitUnion | null {
   if (!text.includes('|')) return null
-  const parts = splitUnionParts(text)
-  if (parts == null || parts.length < 2) return null
+  const parts = text.split('|').map(part => part.trim())
+  // An empty part means `||`, a leading `|`, or a trailing `|` — none of those
+  // are unions. Junk like `a | b` also fails below when parseRangeBoundNumber
+  // rejects the part.
+  if (parts.length < 2 || parts.some(part => part.length === 0)) return null
   const values: number[] = []
   for (const part of parts) {
     const parsed = parseRangeBoundNumber(part)
@@ -367,40 +370,6 @@ export function parseUnionText(text: string): FitUnion | null {
     values: unique,
     text,
   }
-}
-
-function splitUnionParts(text: string): string[] | null {
-  let parenDepth = 0
-  let bracketDepth = 0
-  let braceDepth = 0
-  let quote: '"' | "'" | '`' | null = null
-  const parts: string[] = []
-  let start = 0
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i]
-    if (quote != null) {
-      if (char === '\\') i++
-      else if (char === quote) quote = null
-      continue
-    }
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char
-      continue
-    }
-    if (char === '(') parenDepth++
-    else if (char === ')') parenDepth--
-    else if (char === '[') bracketDepth++
-    else if (char === ']') bracketDepth--
-    else if (char === '{') braceDepth++
-    else if (char === '}') braceDepth--
-    else if (char === '|' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0 && text[i + 1] !== '|' && text[i - 1] !== '|') {
-      parts.push(text.slice(start, i).trim())
-      start = i + 1
-    }
-  }
-  parts.push(text.slice(start).trim())
-  if (parts.some(part => part.length === 0)) return null
-  return parts
 }
 
 function parseRangeText(text: string): FitRange | null {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -365,6 +365,7 @@ export function parseUnionText(text: string): FitUnion | null {
     values.push(parsed)
   }
   const unique = [...new Set(values)].sort((a, b) => a - b)
+  if (unique.length < 2) return null
   return {
     valueKind: unique.every(Number.isInteger) ? 'int' : 'number',
     values: unique,

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript'
 import {
   joinValues,
+  numberValue,
   unknown,
   unknownArray,
   unknownArrayLength,
@@ -8,6 +9,7 @@ import {
   unknownObject,
   type Value,
 } from './domain.ts'
+import {linearConstant, numericLiteralValue} from './linear.ts'
 
 export type ShapeProgram = {
   sourceId: string
@@ -90,6 +92,8 @@ function valueFromTsType(expr: string, type: ts.Type, checker: ts.TypeChecker, l
   if (depth > maxTsShapeDepth) return null
   if (seen.has(type)) return unknownObject(expr)
   if (isNullishTsType(type)) return unknown(`Nullish value is not in the static layout subset: ${expr}`)
+  const literal = tsNumberLiteralValue(type)
+  if (literal != null) return numberLiteralValue(expr, literal)
   if ((type.flags & ts.TypeFlags.NumberLike) !== 0) return unknownNumber(expr)
   if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return unknown(`Boolean values are not in the static layout subset: ${expr}`)
   if ((type.flags & ts.TypeFlags.StringLike) !== 0) return unknown(`String values are not in the static layout subset: ${expr}`)
@@ -134,6 +138,16 @@ function valueFromTsType(expr: string, type: ts.Type, checker: ts.TypeChecker, l
   return {kind: 'object', props, expr}
 }
 
+function tsNumberLiteralValue(type: ts.Type): number | null {
+  if ((type.flags & ts.TypeFlags.NumberLiteral) === 0) return null
+  const value = (type as ts.LiteralType).value
+  return typeof value === 'number' ? value : null
+}
+
+function numberLiteralValue(expr: string, value: number) {
+  return numberValue(value, value, Number.isInteger(value), expr, linearConstant(value))
+}
+
 function isNullishTsType(type: ts.Type) {
   return (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0
 }
@@ -170,7 +184,10 @@ export function valueFromSyntaxTypeShape(expr: string, type: ts.TypeNode | undef
   }
   if (ts.isUnionTypeNode(type)) return valueFromUnionSyntaxType(expr, type, program, seen)
   if (ts.isIntersectionTypeNode(type)) return valueFromIntersectionSyntaxType(expr, type, program, seen)
-  if (ts.isLiteralTypeNode(type)) return unknown(`Literal values are not in the static layout subset: ${expr}`)
+  if (ts.isLiteralTypeNode(type)) {
+    const literal = numericLiteralValue(type.literal)
+    return literal == null ? unknown(`Literal values are not in the static layout subset: ${expr}`) : numberLiteralValue(expr, literal)
+  }
   if (ts.isTypeLiteralNode(type)) return objectValueFromTypeMembers(expr, type.members, program, seen)
   if (ts.isTypeReferenceNode(type)) return valueFromTypeReference(expr, type, program, seen)
   return valueFromTypeNodeShape(expr, type, program)

--- a/test.ts
+++ b/test.ts
@@ -162,6 +162,19 @@ if (missingRedundantFacts.length > 0 || badRedundantSpecStatuses.length > 0) {
   console.log(`infer redundant: ${expectedRedundantFacts.length} expected facts`)
 }
 
+const unionRedundantReport = inferFitFiles(['patterns.ts'], {functionName: 'literalUnionBranchReturn'})
+const unionFunction = unionRedundantReport.functions[0]
+const unionSpecStatuses = new Map(unionFunction?.specs.map(spec => [spec.text, spec.status]) ?? [])
+const unionRedundantFacts = new Map(unionFunction?.redundant.map(fact => [fact.text, fact.reason]) ?? [])
+if (unionSpecStatuses.get('return: 0 | 100') !== 'source-proved' || unionRedundantFacts.has('return: 0 | 100')) {
+  console.error('expected literal-union facts to stay explicit in infer output')
+  if (unionSpecStatuses.get('return: 0 | 100') !== 'source-proved') console.error('missing source-proved union return')
+  if (unionRedundantFacts.has('return: 0 | 100')) console.error(`unexpected redundant union return: ${unionRedundantFacts.get('return: 0 | 100')}`)
+  process.exitCode = 1
+} else {
+  console.log('infer union redundancy: explicit')
+}
+
 const tupleInferReport = inferFitFiles(['patterns.ts'], {functionName: 'scalarStringishMutationPreservesTupleFacts'})
 const tupleFacts = new Set(tupleInferReport.functions[0]?.facts.map(fact => fact.text) ?? [])
 if (!tupleFacts.has('return.length == 2')) {


### PR DESCRIPTION
## Summary
- Two-branch `joinValues` now preserves per-branch cases when the linear forms disagree, so `flag ? A : B` passes discrete identity through `Math.min` and subtraction downstream.
- Adds literal-union numeric types to `@fit given` (block form and inline param form): `given searchSlot: 0 | 40 | 200 | 213` narrows the domain to exactly those values, rejecting call sites that pass a literal outside the set with `missing: x in {...}`.
- Simplifies `parseUnionText` — the defensive paren/bracket/brace/quote tracking in `splitUnionParts` is unnecessary for what is, by contract, a list of numeric literals; `parseUnionText` already validates each part via `parseRangeBoundNumber`.

## Commits
1. `joinValues: preserve cases when ternary branches disagree on linear form` — fix + `pathSensitiveMinOverflowTernaryInset` regression test.
2. `Support literal-union numeric types as @fit given domains` — parser + checker + positive (`literalUnionGivenPassesThrough`, `literalUnionGivenOnParam`) + negative (`negativeUnionReturnOutsideSet`) regression tests + docs.
3. `parseUnionText: drop splitUnionParts paren/quote tracking` — simplification pass.

## Usage in mj-gallery
`src/MidUI/PageLayoutSpec.ts` pillWidthFromSpec uses `given spec.searchSlot: 0 | 40 | 200 | 213` and similar for every `PillSpec` field. The upper-bound proof on the raw sum tightens from widened-range arithmetic to per-branch cases.

## Test plan
- [x] `bun fr.ts check freerange/patterns.ts` — 266 pass
- [x] `bun fr.ts check mj-gallery/src/MidUI/*.ts` — 5 files, 106 pass, 0 fail
- [x] `bun test.ts` — negative/infer/cli suites pass (photo-gallery snapshot drift is pre-existing, unrelated to these commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)