### PR TITLE
feat: run freerange CLI on Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Freerange is deliberately designed to cater to a useful (and growing) subset of 
 ## Install
 
 ```sh
-bun install --dev @chenglou/freerange
+npm install --save-dev @chenglou/freerange
 ```
+
+The `fr` command requires Node.js 18 or newer. Use your package manager's command
+runner (for example, `npx fr` or `pnpm exec fr`) in scripts and CI.
 
 ## API
 
@@ -44,7 +47,7 @@ function gridItemWidth(containerWidth: number) {
 gridItemWidth(200)
 ```
 
-`bun fr` outputs:
+`fr` outputs:
 
 ```zsh
 index.ts:9:1 - error [inferred-requirement]: call to gridItemWidth violates its nonzero divisor requirement (division at index.ts:6:10)

--- a/fr.ts
+++ b/fr.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 // Two commands. `fr` checks the project for warnings and errors; `fr --audit` prints
 // every function's contracts and refactoring suggestions. Both take an optional file that

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,7 +1,7 @@
 import type {KnipConfig} from 'knip'
 
 const config: KnipConfig = {
-  entry: ['demo/index.ts', 'src/index.ts'],
+  entry: ['demo/index.ts', 'fr.ts', 'src/index.ts'],
   ignore: [
     '.claude/workflows/**', // named Workflow scripts, invoked by the agent harness, not imported
     'tests/**/*.ts',

--- a/package.json
+++ b/package.json
@@ -9,22 +9,26 @@
   },
   "type": "module",
   "bin": {
-    "fr": "fr.ts"
+    "fr": "dist/fr.js"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "files": [
     "CHANGELOG.md",
     "LICENSE",
     "README.md",
-    "fr.ts",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "check": "bunx @typescript/native && oxlint --type-aware && bun knip && bun test --parallel=4",
+    "build": "bun build --target=node --external typescript --outdir dist fr.ts",
+    "check": "bun run build && bunx @typescript/native && oxlint --type-aware && bun knip && bun test --parallel=4",
     "demo": "HOST=${HOST:-127.0.0.1}; PORT=${PORT:-3000}; bun ./demo/index.html --host=$HOST:$PORT",
-    "fr": "bun fr.ts"
+    "fr": "node dist/fr.js",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "typescript": "^6.0.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "bun build --target=node --external typescript --outdir dist fr.ts",
     "check": "bun run build && bunx @typescript/native && oxlint --type-aware && bun knip && bun test --parallel=4",
     "demo": "HOST=${HOST:-127.0.0.1}; PORT=${PORT:-3000}; bun ./demo/index.html --host=$HOST:$PORT",
-    "fr": "node dist/fr.js",
+    "fr": "bun run build && node dist/fr.js",
     "prepack": "bun run build"
   },
   "dependencies": {

--- a/tests/project-report.test.ts
+++ b/tests/project-report.test.ts
@@ -5,11 +5,30 @@ import {dirname, join} from 'node:path'
 import * as ts from 'typescript'
 import {formatTypeScriptDiagnostics} from '../src/typescript/diagnostics.ts'
 
-const freerangeCli = new URL('../fr.ts', import.meta.url).pathname
+const freerangeCli = new URL('../dist/fr.js', import.meta.url).pathname
+
+function buildCli(): void {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, 'run', 'build'],
+    cwd: new URL('..', import.meta.url).pathname,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (result.exitCode !== 0) throw new Error('Failed to build the FreeRange CLI')
+}
+
+function findNodeExecutable(): string {
+  const nodeExecutable = Bun.which('node')
+  if (nodeExecutable == null) throw new Error('The project report tests require Node.js')
+  return nodeExecutable
+}
+
+buildCli()
+const nodeExecutable = findNodeExecutable()
 
 function runCli(cwd: string, ...arguments_: string[]) {
   const result = Bun.spawnSync({
-    cmd: [process.execPath, freerangeCli, ...arguments_],
+    cmd: [nodeExecutable, freerangeCli, ...arguments_],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -85,7 +104,7 @@ export function outOfBounds(): number {
     expect(existsSync(join(projectDirectory, 'freerange-report'))).toBe(false)
 
     const colored = Bun.spawnSync({
-      cmd: [process.execPath, freerangeCli],
+      cmd: [nodeExecutable, freerangeCli],
       cwd: projectDirectory,
       env: {...process.env, NO_COLOR: '', FORCE_COLOR: '1'},
       stdout: 'pipe',
@@ -95,7 +114,7 @@ export function outOfBounds(): number {
     expect(colored).toContain('\u001B[90m [out-of-bounds-read]: \u001B[0m')
 
     const coloredAudit = Bun.spawnSync({
-      cmd: [process.execPath, freerangeCli, '--audit'],
+      cmd: [nodeExecutable, freerangeCli, '--audit'],
       cwd: projectDirectory,
       env: {...process.env, NO_COLOR: '', FORCE_COLOR: '1'},
       stdout: 'pipe',


### PR DESCRIPTION
## Summary

Publish a Node-targeted JavaScript bundle and point the `fr` binary to it, removing the Bun runtime requirement for installed users.

The package now ships `dist/fr.js`, documents Node.js 18+, and verifies the emitted CLI through Node in the project-report suite.

## Validation

- `node node_modules/@typescript/native/bin/tsc`
- `node_modules/.bin/oxlint --type-aware`
- `bun knip`
- `bun test --parallel=4`
- `npm --cache /private/tmp/freerange-npm-cache pack --dry-run --ignore-scripts`