### PR TITLE
feat: Analyze numeric intersections with phantom metadata

### DIFF
--- a/src/lower/expression.ts
+++ b/src/lower/expression.ts
@@ -1133,6 +1133,68 @@ type ValueKindResult = 'number' | 'boolean' | 'object' | 'nullable' | 'array' | 
 // taggedUnionProperty gain theirs here.)
 const valueKindCache = new WeakMap<ts.Type, ValueKindResult[]>()
 
+function propertyIsReadonly(property: ts.Symbol): boolean {
+  const declarations = property.getDeclarations()
+  return declarations != null && declarations.length > 0 && declarations.every(declaration =>
+    (ts.getCombinedModifierFlags(declaration) & ts.ModifierFlags.Readonly) !== 0)
+}
+
+function isClassType(type: ts.Type): boolean {
+  return type.getSymbol()?.getDeclarations()?.some(declaration => ts.isClassDeclaration(declaration)) === true
+}
+
+function isMetadataValue(type: ts.Type, checker: ts.TypeChecker, depth: number): boolean {
+  if (depth > 8) return false
+  // `unknown` grants no operations to the phantom field. `any` stays out because it can
+  // hide callable, indexed, or other runtime-significant structure from this validation.
+  if ((type.flags & ts.TypeFlags.Unknown) !== 0) return true
+  const literalFlags = ts.TypeFlags.StringLiteral
+    | ts.TypeFlags.NumberLiteral
+    | ts.TypeFlags.BooleanLiteral
+    | ts.TypeFlags.BigIntLiteral
+    | ts.TypeFlags.UniqueESSymbol
+  if ((type.flags & literalFlags) !== 0) return true
+  if (type.isUnion()) {
+    return type.types.every(member =>
+      (member.flags & ts.TypeFlags.Undefined) !== 0
+      || isMetadataValue(member, checker, depth + 1))
+  }
+  if ((type.flags & ts.TypeFlags.Object) === 0) return false
+  if (checker.isArrayType(type) || checker.isTupleType(type)) return false
+  if (isClassType(type)) return false
+  if (checker.getIndexInfosOfType(type).length > 0) return false
+  if (type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0) return false
+  const properties = checker.getPropertiesOfType(type)
+  return properties.length > 0 && properties.every(property =>
+    propertyIsReadonly(property)
+    && isMetadataValue(checker.getTypeOfSymbol(property), checker, depth + 1))
+}
+
+function isPhantomMetadataObject(type: ts.Type, checker: ts.TypeChecker, depth: number): boolean {
+  if ((type.flags & ts.TypeFlags.Object) === 0) return false
+  if (checker.isArrayType(type) || checker.isTupleType(type)) return false
+  if (isClassType(type)) return false
+  if (checker.getIndexInfosOfType(type).length > 0) return false
+  if (type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0) return false
+  const properties = checker.getPropertiesOfType(type)
+  return properties.length > 0 && properties.every(property =>
+    (property.flags & ts.SymbolFlags.Optional) !== 0
+    && propertyIsReadonly(property)
+    && isMetadataValue(checker.getTypeOfSymbol(property), checker, depth + 1))
+}
+
+function isTransparentNumberIntersection(type: ts.IntersectionType, checker: ts.TypeChecker, depth: number): boolean {
+  let numberMembers = 0
+  for (const member of type.types) {
+    if ((member.flags & ts.TypeFlags.NumberLike) !== 0) {
+      numberMembers++
+      continue
+    }
+    if (!isPhantomMetadataObject(member, checker, depth + 1)) return false
+  }
+  return numberMembers === 1
+}
+
 export function valueKind(type: ts.Type, checker: ts.TypeChecker, depth = 0): ValueKindResult {
   // The depth guard bounds recursion into element types (a recursive `type T = T[]` would
   // otherwise loop); past it, nothing classifies.
@@ -1151,6 +1213,7 @@ export function valueKind(type: ts.Type, checker: ts.TypeChecker, depth = 0): Va
 
 function valueKindUncached(type: ts.Type, checker: ts.TypeChecker, depth: number): ValueKindResult {
   if ((type.flags & ts.TypeFlags.NumberLike) !== 0) return 'number'
+  if (type.isIntersection() && isTransparentNumberIntersection(type, checker, depth)) return 'number'
   if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return 'boolean'
   // Strings are carried without claims: a label or id must not reject the numeric
   // contract of the function around it.

--- a/tests/analyze-number-intersections.test.ts
+++ b/tests/analyze-number-intersections.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, test} from 'bun:test'
+import type {AnalysisReport} from '../src/index.ts'
+import {analyzeSource} from '../src/index.ts'
+import {analyzedFunction, requirementsBesidesInputFiniteness} from './analyze-helpers.ts'
+
+function unsupportedFunction(report: AnalysisReport, name: string) {
+  const fn = report.functions.find(candidate => candidate.name === name)
+  if (fn == null || fn.kind !== 'unsupported') throw new Error(`Expected ${name} to be unsupported`)
+  return fn
+}
+
+describe('numeric intersections with phantom metadata', () => {
+  test('analyzes direct parameters, record fields, and same-file calls as numbers', () => {
+    const report = analyzeSource('number-metadata.ts', `
+      declare const unit: unique symbol
+      type UniqueBranded = number & {readonly [unit]?: 'pixels'}
+      type StringBranded = number & {readonly _brand?: 'pixels'}
+      type Gauged = number & {readonly _gauge?: unknown}
+
+      function reciprocal(value: StringBranded): number {
+        return 1 / value
+      }
+      function plainDirect(width: number): number {
+        return width / 2
+      }
+      export function direct(width: UniqueBranded): number {
+        return width / 2
+      }
+      export function field(box: {width: StringBranded}): number {
+        return box.width / 2
+      }
+      export function propagated(value: StringBranded): number {
+        return reciprocal(value)
+      }
+      export function gauged(value: Gauged): number {
+        return value / 2
+      }
+    `)
+
+    expect(analyzedFunction(report, 'direct').ensures)
+      .toEqual(analyzedFunction(report, 'plainDirect').ensures)
+    expect(analyzedFunction(report, 'field').ensures)
+      .toEqual(analyzedFunction(report, 'plainDirect').ensures)
+    expect(analyzedFunction(report, 'gauged').ensures)
+      .toEqual(analyzedFunction(report, 'plainDirect').ensures)
+    const propagatedRequirements = requirementsBesidesInputFiniteness(analyzedFunction(report, 'propagated'))
+    expect(propagatedRequirements).toHaveLength(1)
+    expect(propagatedRequirements[0]).toStartWith('value is nonzero (division at number-metadata.ts:')
+  })
+
+  test('keeps plain-number contracts unchanged and does not interpret literal metadata', () => {
+    const report = analyzeSource('number-metadata-contracts.ts', `
+      type Ranged = number & {
+        readonly _range?: {readonly min: 0; readonly max: 1}
+        readonly _clamped?: true
+      }
+      export function plain(value: number): number {
+        return value / 2
+      }
+      export function branded(value: Ranged): number {
+        return value / 2
+      }
+    `)
+
+    const plain = analyzedFunction(report, 'plain')
+    const branded = analyzedFunction(report, 'branded')
+    expect(branded.assumptions).toEqual(plain.assumptions)
+    expect(branded.ensures).toEqual(plain.ensures)
+    expect(branded.requires).toHaveLength(plain.requires.length)
+    expect(branded.requires[0]).toContain('Number.isFinite(value)')
+  })
+
+  test('rejects intersections that can add runtime operations or broad data', () => {
+    const report = analyzeSource('number-runtime-intersections.ts', `
+      type BroadField = number & {readonly payload: number}
+      type RequiredLiteral = number & {readonly tag: 'metadata'}
+      type MutableLiteral = number & {tag?: 'metadata'}
+      type RequiredUnknown = number & {readonly metadata: unknown}
+      type MutableUnknown = number & {metadata?: unknown}
+      type AnyMetadata = number & {readonly metadata?: any}
+      type Callable = number & ((input: number) => number)
+      type Constructable = number & {new (): object}
+      type Indexed = number & {readonly [key: string]: 'metadata'}
+      type ArrayLike = number & readonly 'metadata'[]
+      type TupleLike = number & readonly ['metadata']
+      type Method = number & {format(): string}
+      type MixedPrimitive = number & string
+      class RuntimeMetadata { readonly tag = 'metadata' }
+      type Classed = number & RuntimeMetadata
+
+      export function broadField(value: BroadField): number { return value + 1 }
+      export function requiredLiteral(value: RequiredLiteral): number { return value + 1 }
+      export function mutableLiteral(value: MutableLiteral): number { return value + 1 }
+      export function requiredUnknown(value: RequiredUnknown): number { return value + 1 }
+      export function mutableUnknown(value: MutableUnknown): number { return value + 1 }
+      export function anyMetadata(value: AnyMetadata): number { return value + 1 }
+      export function callable(value: Callable): number { return value + 1 }
+      export function constructable(value: Constructable): number { return value + 1 }
+      export function indexed(value: Indexed): number { return value + 1 }
+      export function arrayLike(value: ArrayLike): number { return value + 1 }
+      export function tupleLike(value: TupleLike): number { return value + 1 }
+      export function method(value: Method): number { return value + 1 }
+      export function mixedPrimitive(value: MixedPrimitive): number { return value + 1 }
+      export function classed(value: Classed): number { return value + 1 }
+    `)
+
+    for (const name of [
+      'broadField',
+      'requiredLiteral',
+      'mutableLiteral',
+      'requiredUnknown',
+      'mutableUnknown',
+      'anyMetadata',
+      'callable',
+      'constructable',
+      'indexed',
+      'arrayLike',
+      'tupleLike',
+      'method',
+      'mixedPrimitive',
+      'classed',
+    ]) {
+      expect(unsupportedFunction(report, name).unsupported).toContain('function parameter with type')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- classify `number` intersections as numeric only when every other constituent is an optional readonly metadata record
- allow literal metadata trees and `unknown` phantom values without interpreting units, ranges, clamping, or other refinements
- fail closed for required or mutable fields, `any`, call/construct/index signatures, arrays, tuples, classes, and mixed primitives

Closes #5.

## Validation

- `bun test tests/analyze-number-intersections.test.ts`: 3 passed, 23 assertions
- `bunx @typescript/native && bunx oxlint --type-aware && bun knip`: passed
- `NO_COLOR=1 bun test --max-concurrency=1 --timeout=20000`: 201 passed, 1,554 assertions

The repository default `bun test --parallel=4` exceeded its 5-second per-test timeout for CLI integration tests on this machine and emitted ANSI diagnostics that its snapshots did not strip. The same complete suite passes serially with color disabled and a 20-second timeout.

## Public integration evidence

Tested [this PR revision](https://github.com/chenglou/freerange/pull/6/commits/cda2ebdf27da9f32a4e38e5497b026b8db967ae9) against public [`@penner/smart-primitive` revision `0bb1661`](https://github.com/robertpenner/smart-primitive/tree/0bb1661cc306e67cf36529d09fbe10661e80f929). Using this branch's `fr --audit`:

- [`src/units/angle.ts`](https://github.com/robertpenner/smart-primitive/blob/0bb1661cc306e67cf36529d09fbe10661e80f929/src/units/angle.ts): 9/9 functions fully analyzed
- [`src/units/temperature.ts`](https://github.com/robertpenner/smart-primitive/blob/0bb1661cc306e67cf36529d09fbe10661e80f929/src/units/temperature.ts): 2/2 functions fully analyzed
- [`src/refinementTraits.freerange.ts`](https://github.com/robertpenner/smart-primitive/blob/0bb1661cc306e67cf36529d09fbe10661e80f929/src/refinementTraits.freerange.ts): 12/12 functions fully analyzed

The public fixture also checks the soundness boundary. `reciprocalNormalizedTime` gets its `value > 0` requirement from an executable `console.assert`, and `clampProgressFromSource` gets its `[0, 1]` return guarantee from executable branches. Metadata-only range, clamped, integer, periodic, unit, kind, gauge, and brand controls receive only ordinary finite-number requirements and results.

The companion [runtime and typecheck controls](https://github.com/robertpenner/smart-primitive/blob/0bb1661cc306e67cf36529d09fbe10661e80f929/src/refinementTraits.freerange.test.ts) pass with no type errors and demonstrate that out-of-range, falsely clamped, and fractional values can inhabit these phantom types. No casts, wrappers, alternate APIs, or brand-erasing changes were added to the analyzed source files for Freerange.
